### PR TITLE
feat(game): foul line 컴포넌트 추가

### DIFF
--- a/src/components/game/FoulLine/FoulLine.css.ts
+++ b/src/components/game/FoulLine/FoulLine.css.ts
@@ -1,0 +1,32 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const wrapper = style({
+  position: "relative",
+  width: "100%",
+  height: 3,
+});
+
+const lineBase = style({
+  position: "absolute",
+  inset: 0,
+  opacity: 0.53,
+  borderRadius: vars.radius.s,
+});
+
+export const line = styleVariants({
+  default: [
+    lineBase,
+    {
+      backgroundImage: vars.gradient.game_deadline_default,
+      boxShadow: vars.effect.game_deadline_default,
+    },
+  ],
+  error: [
+    lineBase,
+    {
+      backgroundImage: vars.gradient.game_deadline_error,
+      boxShadow: vars.effect.game_deadline_error,
+    },
+  ],
+});

--- a/src/components/game/FoulLine/FoulLine.tsx
+++ b/src/components/game/FoulLine/FoulLine.tsx
@@ -1,0 +1,23 @@
+import type { HTMLAttributes } from "react";
+import * as styles from "./FoulLine.css";
+
+type FoulLineVariant = "default" | "error";
+
+interface FoulLineProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: FoulLineVariant;
+}
+
+export default function FoulLine({
+  variant = "default",
+  className,
+  ...rest
+}: FoulLineProps) {
+  return (
+    <div
+      className={`${styles.wrapper}${className ? ` ${className}` : ""}`}
+      {...rest}
+    >
+      <div className={styles.line[variant]} />
+    </div>
+  );
+}

--- a/src/styles/tokens/effect.ts
+++ b/src/styles/tokens/effect.ts
@@ -1,5 +1,7 @@
 export const effect = {
   game_selected_default: "0px 4px 44px rgba(0, 208, 251, 0.64)",
   game_selected_error: "0px 4px 44px rgba(252, 91, 113, 0.6)",
+  game_deadline_default: "0px 0px 17.2px 0.5px #00fff2",
+  game_deadline_error: "0px 0px 11.4px 0px #ff0000",
   login_github: "inset 2px 2px 7.6px 0px rgba(70, 172, 190, 0.24)",
 } as const;


### PR DESCRIPTION
## 📂 작업 내용

closes #62

- [x] FoulLine 컴포넌트 구현 (default / error variant)
- [x] game_deadline 관련 effect 디자인 토큰 추가

## 💡 자세한 설명

게임 화면에서 사용되는 FoulLine 컴포넌트를 추가했습니다.
* `default`(청록색)와 `error`(빨간색) 두 가지 variant를 지원하며, Vanilla Extract의 `styleVariants`로 스타일을 분리했습니다.
* effect 토큰에 `game_deadline_default`, `game_deadline_error` box-shadow 값을 추가하여 glow 효과를 적용합니다.

## 📸 스크린샷
<img width="794" height="143" alt="image" src="https://github.com/user-attachments/assets/d0b5ed20-0c1a-4bed-a362-b948ff6afd7b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new foul line visual component to the game interface with support for multiple display states (default and error variants). This enhancement provides clearer visual feedback and improved game status indication during gameplay, helping players understand game conditions at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->